### PR TITLE
Prefix in Mir::Config::Client

### DIFF
--- a/src/Mir-Config-Client/lib/Mir/Config/Client.pm
+++ b/src/Mir-Config-Client/lib/Mir/Config/Client.pm
@@ -215,8 +215,9 @@ sub get_any {
             item
             resource
         )) {
-            $query .= $self->prefix.$params->{$_} if ( defined $params->{$_} );
+            $query .= $params->{$_}."/" if ( defined $params->{$_} );
         }
+        $query = substr($query, 0, length ($query) - 1) if ($query =~ /\/$/);
 
         $self->log->debug( "Query string: $query" );
         $res = eval { $self->ua->get( $query ); };

--- a/src/Mir-Config-Client/t/00-load.t
+++ b/src/Mir-Config-Client/t/00-load.t
@@ -19,6 +19,7 @@ diag "port: 5000";
 ok(my $o=Mir::Config::Client->new( 
 #        host    => 'localhost',
 #        port    => 5000,
+        prefix  =>  '/sco/'
         ), 'new' );
 
 ok(my $component_profile = $o->get_item( 
@@ -35,10 +36,10 @@ ok(my $resource = $o->get_resource(
 diag "Resource 'fetchers':";
 diag Dumper( $resource );
 
-ok(my $h = $o->get_any( 
-#        section => 'system',
-#        item => 'ACQ',
-#        resource => 'fetchers'
+ok(my $h = $o->get_any({ 
+        section => 'profile',
+        item => 'area',
+        }
 ), 'get_any' );
 diag Dumper( $h ) if ( defined $h );
 

--- a/src/Mir/lib/Mir/Acq/Scheduler.pm
+++ b/src/Mir/lib/Mir/Acq/Scheduler.pm
@@ -78,6 +78,7 @@ has 'log'           => (
 has 'campaigns'     => ( is => 'rw', isa => 'ArrayRef', trigger => \&_set_queue );
 has 'fetchers'      => ( is => 'rw', isa => 'ArrayRef' );
 has 'params'        => ( is => 'rw', isa => 'Str' );
+has 'prefix'        => ( is => 'rw', isa => 'Str', default => '/' );
 has 'queues'        => ( is => 'ro', isa => 'HashRef' );
 
 sub _set_queue {
@@ -115,17 +116,20 @@ sub parse_input_params {
     my @fetchers;
     my $params;
     my $config_file;
+    my $prefix;
 
     GetOptions ("campaign=s"        => \@campaigns,
                 "fetcher=s"         => \@fetchers,
                 "params=s"          => \$params,
-                "config-file=s"     => \$config_file
+                "config-file=s"     => \$config_file,
+                "prefix=s"          => \$prefix
     ) or die("Error in command line arguments\n");
 
     die "At least a campaign or a fetcher has to be configured\n" unless ( @campaigns || @fetchers );
 
     $self->campaigns ( \@campaigns  );
     $self->fetchers  ( \@fetchers   );
+    $self->prefix( $prefix )            if ( defined $prefix);
     $self->params( $params )            if ( defined $params );
     $self->config_file( $config_file )  if ( defined $config_file );
 
@@ -160,8 +164,9 @@ sub enqueue_fetchers_of_campaign {
 
     my @items;
     my $c = Mir::Config::Client->new(
-        $self->{config_server},
-        $self->{config_port}
+        host    =>  $self->{config_server},
+        port    =>  $self->{config_port},
+        prefix  =>  $self->{prefix}
     ) or die "No Mir::Config server found...";
 
     my $fetchers = $c->get_resource( 


### PR DESCRIPTION
'prefix' is now provided to Mir::Config::Client as an input parameter